### PR TITLE
Fix pagination token rehydrate ordering (stabilize index token order) (fixes #5)

### DIFF
--- a/guides/stan-assistant-guide.md
+++ b/guides/stan-assistant-guide.md
@@ -435,7 +435,7 @@ When queries behave unexpectedly, check:
 - Paging token handling:
   - You treat `result.pageKeyMap` as an opaque token and pass it unchanged.
   - You keep the same set of index tokens between query calls (same shardQueryMap keys); otherwise pageKeyMap validation will fail.
-  - You keep **index token order stable** between calls. `pageKeyMap` dehydration sorts index tokens, but rehydration uses the caller’s `Object.keys(shardQueryMap)` insertion order; rebuilding the map in a different order can silently corrupt pagination.
+  - **Older versions only:** You keep **index token order stable** between calls. Prior to the fix in PR #4, `pageKeyMap` dehydration sorted index tokens, but rehydration used the caller’s `Object.keys(shardQueryMap)` insertion order; rebuilding the map in a different order could silently corrupt pagination.
   - You reuse the **same `timestampFrom`/`timestampTo` bounds** between paged calls. The token does not encode the time window, and `timestampTo` defaults to `Date.now()` per call; changing the window can trigger `dehydrated length mismatch` or mis-page.
 - Projection invariants:
   - If using projections, your adapter auto-included uniqueProperty and sort keys at runtime.

--- a/guides/stan-assistant-guide.md
+++ b/guides/stan-assistant-guide.md
@@ -435,6 +435,8 @@ When queries behave unexpectedly, check:
 - Paging token handling:
   - You treat `result.pageKeyMap` as an opaque token and pass it unchanged.
   - You keep the same set of index tokens between query calls (same shardQueryMap keys); otherwise pageKeyMap validation will fail.
+  - You keep **index token order stable** between calls. `pageKeyMap` dehydration sorts index tokens, but rehydration uses the caller’s `Object.keys(shardQueryMap)` insertion order; rebuilding the map in a different order can silently corrupt pagination.
+  - You reuse the **same `timestampFrom`/`timestampTo` bounds** between paged calls. The token does not encode the time window, and `timestampTo` defaults to `Date.now()` per call; changing the window can trigger `dehydrated length mismatch` or mis-page.
 - Projection invariants:
   - If using projections, your adapter auto-included uniqueProperty and sort keys at runtime.
 - “limit” expectations:

--- a/src/EntityManager/query.test.ts
+++ b/src/EntityManager/query.test.ts
@@ -157,17 +157,19 @@ describe('query', function () {
       lastName: lastNameQuery,
     };
 
+    // IMPORTANT: trigger the bug by first generating the token with the sorted-key map,
+    // then consuming it with the unsorted-key map.
     let result = await query(entityManager, {
       entityToken: 'user',
       item: {},
-      shardQueryMap: mapBoth,
+      shardQueryMap: mapBothReversed,
     });
 
     result = await query(entityManager, {
       entityToken: 'user',
       item: {},
       pageKeyMap: result.pageKeyMap,
-      shardQueryMap: mapBothReversed,
+      shardQueryMap: mapBoth,
     });
 
     expect(result.count).to.be.greaterThan(

--- a/src/EntityManager/query.test.ts
+++ b/src/EntityManager/query.test.ts
@@ -147,6 +147,34 @@ describe('query', function () {
     );
   });
 
+  it('pageKeyMap is stable even if shardQueryMap key insertion order changes', async function () {
+    const mapBothReversed: ShardQueryMap<
+      MyConfigMap,
+      'user',
+      'lastName' | 'firstName'
+    > = {
+      firstName: firstNameQuery,
+      lastName: lastNameQuery,
+    };
+
+    let result = await query(entityManager, {
+      entityToken: 'user',
+      item: {},
+      shardQueryMap: mapBoth,
+    });
+
+    result = await query(entityManager, {
+      entityToken: 'user',
+      item: {},
+      pageKeyMap: result.pageKeyMap,
+      shardQueryMap: mapBothReversed,
+    });
+
+    expect(result.count).to.be.greaterThan(
+      entityManager.config.entities.user.defaultLimit,
+    );
+  });
+
   it('complex sharded query', async function () {
     let result = await query(entityManager, {
       entityToken: 'user',

--- a/src/EntityManager/query.ts
+++ b/src/EntityManager/query.ts
@@ -81,7 +81,7 @@ export async function query<
     >(
       entityManager,
       entityToken,
-      Object.keys(shardQueryMap) as ITS[],
+      (Object.keys(shardQueryMap).sort() as ITS[]),
       item,
       pageKeyMap
         ? (JSON.parse(


### PR DESCRIPTION
# PR: fix/pagination-token-order — Stabilize pagination token rehydrate ordering

## Summary
This PR fixes a subtle pagination footgun in `EntityManager.query()` where the pageKeyMap token can be rehydrated against the *wrong* index if the caller rebuilds `shardQueryMap` with a different **insertion order** between pages.

Root cause:
- `dehydratePageKeyMap()` **sorts** index tokens before flattening to an array
- `query()` previously rehydrated using `Object.keys(shardQueryMap)` which preserves **insertion order**

If insertion order changes across calls, the same dehydrated token may map page keys to the wrong index.

## Changes
- **Fix:** `query()` now passes `Object.keys(shardQueryMap).sort()` into `rehydratePageKeyMap()` so ordering matches dehydration.
- **Test:** adds a regression test that pages using a reversed `shardQueryMap` insertion order.
- **Docs:** updates `guides/stan-assistant-guide.md` to warn about:
  - index-token insertion-order stability (until fixed / for old versions), and
  - stable `timestampFrom`/`timestampTo` bounds across pages (token does not encode them).

## Why it matters
Callers are encouraged to treat `result.pageKeyMap` as **opaque**, but the prior behavior made it effectively order-dependent. This fix makes the token robust to common integration patterns where objects are rebuilt programmatically (e.g., via `BaseQueryBuilder.build()`).

## Commit / branch
- Branch: `fix/pagination-token-order`
- Commit: `20e1243`

## How to open the PR (manual)
Open:
- https://github.com/karmaniverous/entity-manager/pull/new/fix/pagination-token-order

Suggested title:
- `Fix pagination token rehydrate ordering (stabilize index token order)`

Suggested body: (copy/paste this doc’s Summary + Changes sections)

## Follow-ups (not in this PR)
- DONE vs NOT_STARTED conflation: `undefined` is used for both “start” and “exhausted”; fixing this cleanly likely requires a token format v2 / sentinel persisted in the dehydrated token.
