### PR TITLE
fix: sort indexTokens before rehydrate to prevent paging corruption

### DIFF
--- a/src/EntityManager/query.test.ts
+++ b/src/EntityManager/query.test.ts
@@ -147,6 +147,41 @@ describe('query', function () {
     );
   });
 
+  it('reversed index order produces identical page 2 results', async function () {
+    const mapBothReversed: ShardQueryMap<
+      MyConfigMap,
+      'user',
+      'firstName' | 'lastName'
+    > = { firstName: firstNameQuery, lastName: lastNameQuery };
+
+    // Page 1 with original order.
+    const page1 = await query(entityManager, {
+      entityToken: 'user',
+      item: {},
+      shardQueryMap: mapBoth,
+    });
+
+    // Page 2 with original order.
+    const page2Original = await query(entityManager, {
+      entityToken: 'user',
+      item: {},
+      pageKeyMap: page1.pageKeyMap,
+      shardQueryMap: mapBoth,
+    });
+
+    // Page 2 with reversed order using same pageKeyMap from page 1.
+    const page2Reversed = await query(entityManager, {
+      entityToken: 'user',
+      item: {},
+      pageKeyMap: page1.pageKeyMap,
+      shardQueryMap: mapBothReversed,
+    });
+
+    expect(page2Reversed.count).to.equal(page2Original.count);
+    expect(page2Reversed.pageKeyMap).to.equal(page2Original.pageKeyMap);
+    expect(page2Reversed.items).to.deep.equal(page2Original.items);
+  });
+
   it('complex sharded query', async function () {
     let result = await query(entityManager, {
       entityToken: 'user',

--- a/src/EntityManager/query.ts
+++ b/src/EntityManager/query.ts
@@ -81,7 +81,7 @@ export async function query<
     >(
       entityManager,
       entityToken,
-      Object.keys(shardQueryMap) as ITS[],
+      (Object.keys(shardQueryMap) as ITS[]).sort(),
       item,
       pageKeyMap
         ? (JSON.parse(


### PR DESCRIPTION
Closes #5

## Problem

dehydratePageKeyMap sorts index tokens before serializing page keys:

`	s
const indexes = Object.keys(pageKeyMap).sort() as ITS[];
`

But query() passes unsorted Object.keys(shardQueryMap) to ehydratePageKeyMap. If the caller's shardQueryMap has a different insertion order between page 1 and page 2, dehydrated page keys get applied to the wrong index — silent paging corruption.

## Fix

Sort index tokens before passing to ehydratePageKeyMap in query.ts:

`	s
(Object.keys(shardQueryMap) as ITS[]).sort()
`

## Regression test

Added test that queries page 1, then queries page 2 twice — once with original shardQueryMap key order and once with reversed order — and asserts identical results (count, items, pageKeyMap).

All 102 tests pass.