### PR TITLE
chore: move changelog generation to after:bump hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,15 +101,15 @@
         "npm run knip",
         "npm run build"
       ],
-      "before:npm:release": [
-        "npx auto-changelog -p",
-        "npm run docs",
-        "git add -A"
-      ],
       "after:release": [
         "git switch -c release/${version}",
         "git push -u origin release/${version}",
         "git switch ${branchName}"
+      ],
+      "after:bump": [
+        "npx auto-changelog -p",
+        "npm run docs",
+        "git add CHANGELOG.md"
       ]
     },
     "npm": {


### PR DESCRIPTION
Move auto-changelog generation from before:npm:release to after:bump so the updated CHANGELOG.md is included in the release commit and tag. Also narrows git add -A to git add CHANGELOG.md to avoid staging unrelated files.